### PR TITLE
Update access_log configuration options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,5 @@ script:
     | grep -q 'changed=0.*failed=0'
     && (echo 'Idempotence test: pass' && exit 0)
     || (echo 'Idempotence test: fail' && exit 1)
+after_failure:
+  - cat /etc/nginx/nginx.conf

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -38,8 +38,10 @@ http {
   access_log    off;
 {% else %}
 {% for log in nginx_access_logs %}
+{% if 'format' in log %}
   log_format  {{log['name']}}  {{log['format']}};
-  access_log    {{nginx_log_dir}}/{{log['filename']}} {{log['name']}}{% if log['options'] %} {{log['options']}}{% endif %};
+{% endif %}
+  access_log    {{nginx_log_dir}}/{{log['filename']}} {{log['name']}}{% if 'options' in log and log['options']|lower != 'none' %} {{log['options']}}{% endif %};
 {% endfor %}
 {% endif %}
 {% if nginx_server_tokens %}


### PR DESCRIPTION
Under `nginx_access_logs` option,
- If `format` is not defined, do not output `log_format`
- If `options` is not defined, do not output anything

This allows the following configuration 

```
nginx_access_logs:
  - name: "combined"
    filename: "access.log"
```

to generate a line like this:

`access_log    /var/log/nginx/access.log combined`
